### PR TITLE
Chore: add gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image: gitpod/workspace-dotnet
+
+tasks:
+  - name: Restore & Build
+    init: |
+      dotnet dev-certs https 
+      dotnet restore
+      dotnet build
+
+vscode:
+  extensions:
+    - muhammad-sammy.csharp


### PR DESCRIPTION
## Что это

Gitpod - это облачная IDE (Vscode в браузере)

## Зачем нужен этот файл

Workspace в gitpod работает как docker-контейнер и чтобы добавить туда поддержку dotnet нужно это указать в конфигурационном файле

Сервис разрабатывали твари, поэтому если этот файл создать в самом workspace и не за коммитить в сам репозиторий, то он не используется во время конфигурации

## TL;DR

Ничего страшного для проекта файл не делает, просто можно будет комфортно контрибутить в EntityManager с любого утройства

(Значит ли это, что я буду теперь срать этим файликом в каждый репозиторий - нет, постараюсь минимизировать своё облачное присутствие в секте)